### PR TITLE
Add publish queue for MQTT publisher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - 2025-06-08 
 ### Added
 - feat: enhance MqttPublisher to skip unchanged messages and add unit tests
+- feat: add publish queue to MqttPublisher to avoid message loss
 
 ## [16.15.11] - 2025-06-07
 ### Changed

--- a/nodebackend/src/utils/mqttPublisher.ts
+++ b/nodebackend/src/utils/mqttPublisher.ts
@@ -1,4 +1,4 @@
-import mqtt, { MqttClient } from 'mqtt';
+import mqtt, { MqttClient, IClientPublishOptions } from 'mqtt';
 import * as envSwitcher from '../envSwitcher';
 import * as vaultClient from '../clients/vaultClient';
 import logger from '../logger';
@@ -13,6 +13,8 @@ interface Credentials {
 class MqttPublisher {
   private client: MqttClient | undefined;
   private lastPayload: Record<string, string> = {};
+  private inflight: Record<string, boolean> = {};
+  private queued: Record<string, string> = {};
 
   constructor() {
     (async () => {
@@ -49,23 +51,43 @@ class MqttPublisher {
   }
 
   // Check if client is initialized before publishing
-  publish(mqttTopic: string, message: string, options = {}, callback: () => void = () => {}): void {
-    if (this.lastPayload[mqttTopic] === message) {
-      logger.debug(`Skip publish - unchanged (${mqttTopic} = ${message})`);
+  publish(
+    topic: string,
+    message: string,
+    options: IClientPublishOptions = {},
+    callback: () => void = () => {}
+  ): void {
+    if (!this.client) throw new Error('MQTT Client not initialized');
+
+    // 1) identische Wiederholung trotzdem schlucken
+    if (this.lastPayload[topic] === message) {
+      logger.debug(`Skip publish – unchanged (${topic}=${message})`);
       return;
     }
-    if (!this.client) {
-      logger.error('MQTT Client is not initialized');
-      throw new Error('MQTT Client is not initialized');
+
+    // 2) ist gerade ein Publish unterwegs? ⇒ in Queue ablegen
+    if (this.inflight[topic]) {
+      this.queued[topic] = message; // Merke nur den NEUESTEN
+      logger.debug(`Queue publish (${topic}=${message})`);
+      return;
     }
-    
-    this.client.publish(mqttTopic, message, options, err => {
-      if (err) {
-        logger.error(`MQTT publish error (${mqttTopic})`, err);
+
+    // 3) senden
+    this.inflight[topic] = true;
+    this.client.publish(topic, message, options, err => {
+      this.inflight[topic] = false;
+
+      if (err) logger.error(`MQTT publish error (${topic}):`, err);
+      else this.lastPayload[topic] = message;
+
+      // 4) war währenddessen etwas gequeued?
+      if (this.queued[topic] !== undefined) {
+        const next = this.queued[topic];
+        delete this.queued[topic];
+        this.publish(topic, next, options, callback); // sofort nachschieben
       } else {
-        this.lastPayload[mqttTopic] = message;
+        callback();
       }
-      callback();
     });
   }
 

--- a/nodebackend/test/utils/mqttPublisher.test.ts
+++ b/nodebackend/test/utils/mqttPublisher.test.ts
@@ -43,4 +43,47 @@ describe('MqttPublisher', () => {
 
         expect(publishMock).not.toHaveBeenCalled();
     });
+
+    test('queues publish while previous is inflight', () => {
+        const pub = new MqttPublisher();
+        (pub as any).client = fakeClient;
+
+        let cb: Function | undefined;
+        publishMock.mockImplementationOnce((t: string, m: string, o: any, c: Function) => { cb = c; })
+                   .mockImplementation((t: string, m: string, o: any, c: Function) => c());
+
+        pub.publish('topic/1', 'on');
+        pub.publish('topic/1', 'off');
+
+        expect(publishMock).toHaveBeenCalledTimes(1);
+        expect((pub as any).queued['topic/1']).toBe('off');
+
+        cb && cb();
+
+        expect(publishMock).toHaveBeenCalledTimes(2);
+        expect(publishMock.mock.calls[1][1]).toBe('off');
+        expect((pub as any).queued['topic/1']).toBeUndefined();
+        expect((pub as any).lastPayload['topic/1']).toBe('off');
+    });
+
+    test('keeps only latest queued message', () => {
+        const pub = new MqttPublisher();
+        (pub as any).client = fakeClient;
+
+        let cb: Function | undefined;
+        publishMock.mockImplementationOnce((t: string, m: string, o: any, c: Function) => { cb = c; })
+                   .mockImplementation((t: string, m: string, o: any, c: Function) => c());
+
+        pub.publish('topic/1', 'A');
+        pub.publish('topic/1', 'B');
+        pub.publish('topic/1', 'C');
+
+        expect(publishMock).toHaveBeenCalledTimes(1);
+        expect((pub as any).queued['topic/1']).toBe('C');
+
+        cb && cb();
+
+        expect(publishMock).toHaveBeenCalledTimes(2);
+        expect(publishMock.mock.calls[1][1]).toBe('C');
+    });
 });


### PR DESCRIPTION
## Summary
- implement inflight/queued logic in `MqttPublisher`
- extend unit tests for new publish queue behaviour
- document change in `CHANGELOG`

## Testing
- `npm test --prefix nodebackend`

------
https://chatgpt.com/codex/tasks/task_e_6845829c18d8832ab48563db7154e8b9